### PR TITLE
fix: component name for restproducer

### DIFF
--- a/support/get-logs.sh
+++ b/support/get-logs.sh
@@ -38,7 +38,7 @@ declare -a ES_COMPONENTS=(
     "kafka"
     "proxy"
     "rest"
-    "rest-producer"
+    "restproducer"
     "restproxy"
     "replicator"
     "schemaregistry"


### PR DESCRIPTION
Rest producer logs are not being pulled into
diagnostics

Signed-off-by: tagarr