### PR TITLE
feat: add some functionality to get logs

### DIFF
--- a/support/get-logs.sh
+++ b/support/get-logs.sh
@@ -11,7 +11,7 @@
 #
 
 PROGRAM_NAME="${0}"
-VERSION="2020.2.1"
+VERSION="2020.2.2"
 DATE=`date +%d-%m-%y`
 TIME=`date +%H-%M-%S`
 


### PR DESCRIPTION
get the oidc registration client
Closes: mhub/qp-planning#4506

get events in the install namespace
Closes: mhub/qp-planning#4051

get logs of nodes if using oc

Contributes to: mhub/qp-planning#5638

Signed-off-by: Chris Patmore <christopher.patmore@ibm.com>