### PR TITLE
5616 zookeeper checks

### DIFF
--- a/support/get-logs.sh
+++ b/support/get-logs.sh
@@ -11,7 +11,7 @@
 #
 
 PROGRAM_NAME="${0}"
-VERSION="2020.2.3"
+VERSION="2020.2.4"
 DATE=`date +%d-%m-%y`
 TIME=`date +%H-%M-%S`
 
@@ -615,10 +615,6 @@ if [ "${HAS_ROUTES}" -eq 0 ]; then
     done
 fi
 
-printf "Gathering events in the namespace" | printAndLog
-oc get events -n "${NAMESPACE}" -o wide --sort-by='{.lastTimestamp}' > "${LOGDIR}/${NAMESPACE}-events.log"
-printDoneAndLog
-
 # ####################################################################################################
 # # Gather logs/descriptions/manifests for supporting elements. Helm, ICP, CS etc.
 # ####################################################################################################
@@ -662,8 +658,8 @@ for COMPONENT_LABEL in ${SUPPORTING_COMPONENTS_LABELS[@]}; do
     done 
 done
 
-printf "Gathering events in the ${SUPPORTING_COMPONENTS_NAMESPACE} namespace" | printAndLog
-oc get events -n "${SUPPORTING_COMPONENTS_NAMESPACE}" -o wide --sort-by='{.lastTimestamp}' > "${LOGDIR}/${SUPPORTING_COMPONENTS_NAMESPACE}-events.log"
+printf "Gathering events in all namespaces" | printAndLog
+oc get events --all-namespaces -o wide > "${LOGDIR}/all-events.log"
 printDoneAndLog
 
 printf "Gather node logs if applicable\n" | printAndLog

--- a/support/get-logs.sh
+++ b/support/get-logs.sh
@@ -11,7 +11,7 @@
 #
 
 PROGRAM_NAME="${0}"
-VERSION="2020.2.5"
+VERSION="2020.2.4"
 DATE=`date +%d-%m-%y`
 TIME=`date +%H-%M-%S`
 

--- a/support/get-logs.sh
+++ b/support/get-logs.sh
@@ -210,9 +210,9 @@ declare -a HELM_COMPONENT_LABELS=(
 )
 
 declare -a HELM_PERSISTENT_COMPONENT_LABELS=(
-    "component=kafka"
-    "component=schemaregistry"
-    "component=zookeeper"
+    "serviceSelector=kafka-sts"
+    "serviceSelector=schemaregistry-sts"
+    "serviceSelector=zookeeper-sts"
 )
 
 declare -a HELM_EXTERNAL_ENDPOINTS_SERVICES=(

--- a/support/get-logs.sh
+++ b/support/get-logs.sh
@@ -545,7 +545,7 @@ for LABEL in ${PERSISTENT_COMPONENT_LABELS[@]}; do
     fi
 done
 
-# Check to see if zookeepers can communicate (this is a sucky diff between Op and Helm)
+# Check to see if zookeepers are okay and which is the leader
 ZK_PODS=$(${EXE} get pods -n ${NAMESPACE} -l ${RELEASE_LABEL} -l "app.kubernetes.io/name=zookeeper" --no-headers -o custom-columns=":metadata.name" | cleanOutput)
 for POD in ${ZK_PODS[@]}; do
     printf "Checking zookeeper pod ${POD}\n" | printAndLog


### PR DESCRIPTION
sorting doesn't work and is a pain. Basically it doesn't
work for --all-namespaces anyway (which was originally
desired) and it doesn't always work on a single
namespace because some events have null lastTimestamps
which causes it to blow up

begin implementation of ZK checks. To start with just checking each thinks it is okay and finding the leader

add in CR and CRD checks
add some extra resources as per strimzi
getting image tags was added
add init container logs

Contributes to: mhub/qp-planning#5616
Contributes to: mhub/qp-planning#5638

Signed-off-by: Chris Patmore <christopher.patmore@ibm.com>