### PR TITLE
feat: Add Clients CA certificate in getlogs script

### DIFF
--- a/support/get-logs.sh
+++ b/support/get-logs.sh
@@ -159,6 +159,7 @@ declare -a OPERATOR_CERT_SECRETS=(
     "ibm-es-schema-cert"
     "ibm-es-metrics-cert"
     "cluster-ca-cert"
+    "clients-ca-cert"
     "kafka-brokers"
 )
 


### PR DESCRIPTION
The commit adds the Clients CA Cert to the list of
certificates we log in the must gather script. This
CA is the CA that signs the Mutual TLS Client
certificates.

Contributes to: mhub/qp-planning#6790
Signed-off-by: Tim Mitchell <tim_mitchell@uk.ibm.com>