### PR TITLE
feat: Add the Zookeeper generated certs

### DIFF
--- a/support/get-logs.sh
+++ b/support/get-logs.sh
@@ -160,6 +160,7 @@ declare -a OPERATOR_CERT_SECRETS=(
     "ibm-es-metrics-cert"
     "cluster-ca-cert"
     "kafka-brokers"
+    "zookeeper-nodes"
 )
 
 declare -a OPERATOR_CRDS=(


### PR DESCRIPTION
This commit adds the zookeeper generated
certs to the must gather output. This will
help with issues when ZK doesn't start due to
certificate issues.

Contributes to: velox/events-planning#6797
Signed-off-by: Tim Mitchell <tim_mitchell@uk.ibm.com>